### PR TITLE
fix(docs): Correct README clone URL to circlefin/arc-escrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Automate escrow-backed freelance agreements with AI-powered work validation usin
 1. Clone the repository and install dependencies:
 
    ```bash
-   git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
-   cd workflow-escrow-refund-protocol
+   git clone git@github.com:circlefin/arc-escrow.git
+   cd arc-escrow
    npm install
    ```
 


### PR DESCRIPTION
## Summary

The README's "Getting Started" section uses an internal repository name
in the clone command, which returns 404 for new contributors:

```bash
git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
cd workflow-escrow-refund-protocol
```

The correct public repository is `circlefin/arc-escrow`. This blocks
the entire setup flow on the very first step.

## Change

```diff
-git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
-cd workflow-escrow-refund-protocol
+git clone git@github.com:circlefin/arc-escrow.git
+cd arc-escrow
```

## Verification

```bash
$ git ls-remote git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
ERROR: Repository not found.

$ git ls-remote git@github.com:circlefin/arc-escrow.git
✅ resolves
```

## Related

The same `akelani-circle/...` pattern also appeared in
[`arc-fintech`](https://github.com/circlefin/arc-fintech) and was 
addressed in [arc-fintech#9](https://github.com/circlefin/arc-fintech/pull/9) 
by @skyc1e. This PR applies the same fix to `arc-escrow`.

## Notes

- This is a documentation-only change (1 file, +1/-1 net change after `cd`).
- The repository title appears to be undergoing a separate rename via 
  `akelani-circle-patch-1` branch ("Workflow Escrow Refund Protocol" → 
  "Arc Escrow"); this PR is independent and only fixes the broken clone URL.