### PR TITLE
docs(readme): fix incorrect git clone URL in Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Automate escrow-backed freelance agreements with AI-powered work validation usin
 1. Clone the repository and install dependencies:
 
    ```bash
-   git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
-   cd workflow-escrow-refund-protocol
+   git clone git@github.com:circlefin/arc-escrow.git
+   cd arc-escrow
    npm install
    ```
 


### PR DESCRIPTION
The README's Getting Started section currently points to a personal repo that isn't publicly accessible:

\`\`\`
git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
cd workflow-escrow-refund-protocol
\`\`\`

Step 1 fails for any new contributor — \`akelani-circle/workflow-escrow-refund-protocol\` isn't reachable, and the directory name doesn't match the canonical \`arc-escrow\`.

Updated to the canonical public location:

\`\`\`
git clone git@github.com:circlefin/arc-escrow.git
cd arc-escrow
\`\`\`

Same fix applied to \`arc-fintech\` in [#18](https://github.com/circlefin/arc-fintech/pull/18); separate PR for \`arc-p2p-payments\` to follow.