### PR TITLE
fix: verify caller is beneficiary before processing refund

### DIFF
--- a/app/api/contracts/escrow/refund/route.ts
+++ b/app/api/contracts/escrow/refund/route.ts
@@ -95,6 +95,17 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Could not find a profile linked to the given wallet ID" }, { status: 500 });
     }
 
+    // Verify the caller is the beneficiary of this agreement
+    const isBeneficiary =
+      contractTransaction.beneficiary_wallet_id === depositorWallet.id;
+
+    if (!isBeneficiary) {
+      return NextResponse.json(
+        { error: "Forbidden: Only the beneficiary can initiate a refund" },
+        { status: 403 }
+      );
+    }
+
     // Retrieves contract data from Circle's SDK
     const contractData = await circleContractSdk.getContract({
       id: contractTransaction.circle_contract_id


### PR DESCRIPTION
## Problem

`app/api/contracts/escrow/refund/route.ts` authenticates the caller but never verifies that the caller is the **beneficiary** of the agreement being refunded.

The handler:
1. Calls `supabase.auth.getUser()` ✅
2. Looks up the caller's wallet (`depositorWallet`) for the DB transaction record ✅
3. Fetches `contractTransaction` from the agreement ✅
4. Calls `refundByRecipient` using **`contractTransaction.beneficiary_wallet.circle_wallet_id`** — the beneficiary's wallet, NOT the caller's ❌

The role check that ties the caller to the beneficiary is missing entirely.

### Exploit

Any authenticated user who knows or guesses a `circleContractId` can:

```bash
curl -X POST /api/contracts/escrow/refund \
  -H "Authorization: Bearer <any-valid-session-token>" \
  -d '{"circleContractId": "<target-agreement-id>"}'
```

The handler validates the session (any session works), looks up the caller's wallet (used only for the DB transaction log), then executes `refundByRecipient` against the **real beneficiary's** Circle wallet. The on-chain refund fires, draining locked escrow funds back to the depositor — without the actual beneficiary's consent.

The on-chain refund call is irreversible.

## Fix

Added an explicit ownership check immediately after `depositorWallet` and `contractTransaction` are fetched, before any Circle SDK call:

```diff
+ // Verify the caller is the beneficiary of this agreement
+ const isBeneficiary =
+   contractTransaction.beneficiary_wallet_id === depositorWallet.id;
+
+ if (!isBeneficiary) {
+   return NextResponse.json(
+     { error: "Forbidden: Only the beneficiary can initiate a refund" },
+     { status: 403 }
+   );
+ }

  // Retrieves contract data from Circle's SDK
  const contractData = await circleContractSdk.getContract({ ... });
```

The check compares:
- `contractTransaction.beneficiary_wallet_id` — the FK on the agreement row (joined via `escrow_agreements_beneficiary_wallet_id_fkey`)
- `depositorWallet.id` — the caller's own wallet (despite the variable name, this is just the authenticated user's wallet)

If they don't match, the request is rejected with **403** before any Circle SDK calls are made.

## Impact

- **Security:** Closes a Critical IDOR — only the actual beneficiary can initiate a refund of their own locked funds
- **Risk:** Low — legitimate beneficiary refunds are unaffected; unauthorized callers now get a proper 403
- **Consistency:** The pattern matches the wallet ownership checks already used in `wallet/transfer/route.ts`

This change adds 11 lines and touches only one file.