### PR TITLE
fix: account for prior withdrawals in refund amount calculation

### DIFF
--- a/contracts/escrow_smart_contract/RefundProtocol.sol
+++ b/contracts/escrow_smart_contract/RefundProtocol.sol
@@ -116,13 +116,14 @@ contract RefundProtocol is EIP712 {
             revert CallerNotAllowed();
         }
 
+        uint256 refundAmount = payment.amount - payment.withdrawnAmount;
         uint256 recipientBalance = balances[payment.to];
 
-        if (payment.amount > recipientBalance) {
+        if (refundAmount > recipientBalance) {
             revert InsufficientFunds();
         }
 
-        balances[payment.to] = recipientBalance - payment.amount;
+        balances[payment.to] = recipientBalance - refundAmount;
 
         _executeRefund(paymentID, payment);
     }
@@ -137,21 +138,22 @@ contract RefundProtocol is EIP712 {
     function refundByArbiter(uint256 paymentID) external onlyArbiter {
         Payment memory payment = payments[paymentID];
 
+        uint256 refundAmount = payment.amount - payment.withdrawnAmount;
         uint256 recipientBalance = balances[payment.to];
 
-        if (payment.amount <= recipientBalance) {
-            balances[payment.to] = recipientBalance - payment.amount;
+        if (refundAmount <= recipientBalance) {
+            balances[payment.to] = recipientBalance - refundAmount;
             return _executeRefund(paymentID, payment);
         }
 
         uint256 arbiterBalance = balances[arbiter];
 
-        if (payment.amount > arbiterBalance) {
+        if (refundAmount > arbiterBalance) {
             revert InsufficientFunds();
         }
 
-        balances[arbiter] = arbiterBalance - payment.amount;
-        debts[payment.to] += payment.amount;
+        balances[arbiter] = arbiterBalance - refundAmount;
+        debts[payment.to] += refundAmount;
 
         _executeRefund(paymentID, payment);
     }
@@ -345,11 +347,12 @@ contract RefundProtocol is EIP712 {
         if (payment.refunded) {
             revert PaymentRefunded(paymentID);
         }
-        fiatToken.transfer(payment.refundTo, payment.amount);
-
+        uint256 refundAmount = payment.amount - payment.withdrawnAmount;
+        if (refundAmount > 0) {
+            fiatToken.transfer(payment.refundTo, refundAmount);
+        }
         payments[paymentID].refunded = true;
-
-        emit Refund(paymentID, payment.refundTo, payment.amount);
+        emit Refund(paymentID, payment.refundTo, refundAmount);
     }
 
     /**


### PR DESCRIPTION
## Problem

`RefundProtocol._executeRefund` always transfers `payment.amount` to the refund recipient, ignoring any amount already paid out via `earlyWithdrawByArbiter`.

This creates an accounting inconsistency: the recipient's `balances` mapping has already been decreased by `withdrawnAmount` when the early withdrawal ran, but the refund logic charges the recipient (or arbiter) for the full `payment.amount`.

### Scenario
1-Depositor deposits 100 USDC → payment.amount = 100, withdrawnAmount = 0
2-earlyWithdrawByArbiter releases 30 USDC → withdrawnAmount = 30, recipient balance -= 30
3-refundByRecipient is called
   -InsufficientFunds check: compares 100 against recipient balance
(which is already 30 short)
   -balances[recipient] -= 100  ← over-deducts by 30
   -fiatToken.transfer(refundTo, 100)  ← over-pays by 30

The same pattern applies to `refundByArbiter`:
- The InsufficientFunds check compares against the full `payment.amount`
- `debts[payment.to]` is incremented by `payment.amount` instead of just the shortfall

### Impact

- **Recipient is double-charged** for the already-withdrawn portion — their balance is reduced by the gross deposit, not the net.
- **Arbiter overpays** the refundTo address by `withdrawnAmount`, since the on-chain refund transfers more USDC than the contract actually still holds for this payment.
- **`debts[recipient]` is inflated** to the full `payment.amount` rather than the actual shortfall, distorting any debt-recovery logic that consumes this mapping.

## Fix

Three places updated in `RefundProtocol.sol`:

### 1. `refundByRecipient`

```diff
+ uint256 refundAmount = payment.amount - payment.withdrawnAmount;
  uint256 recipientBalance = balances[payment.to];

- if (payment.amount > recipientBalance) {
+ if (refundAmount > recipientBalance) {
      revert InsufficientFunds();
  }

- balances[payment.to] = recipientBalance - payment.amount;
+ balances[payment.to] = recipientBalance - refundAmount;
```

### 2. `refundByArbiter`

Same `refundAmount` computation, applied to both branches (recipient-covers-it and arbiter-covers-it). Crucially, `debts[payment.to]` now records only the shortfall the arbiter actually paid, not the full original amount.

### 3. `_executeRefund`

```diff
function _executeRefund(uint256 paymentID, Payment memory payment) internal {
    if (payment.refunded) revert PaymentRefunded(paymentID);
+   uint256 refundAmount = payment.amount - payment.withdrawnAmount;
+   if (refundAmount > 0) {
-       fiatToken.transfer(payment.refundTo, payment.amount);
+       fiatToken.transfer(payment.refundTo, refundAmount);
+   }
    payments[paymentID].refunded = true;
-   emit Refund(paymentID, payment.refundTo, payment.amount);
+   emit Refund(paymentID, payment.refundTo, refundAmount);
}
```

The `refundAmount > 0` guard handles the edge case where the entire amount was already early-withdrawn (refund becomes a no-op transfer but still marks the payment refunded).

## Note for subgraph indexers

The `Refund` event's `amount` argument now emits the **actual transferred amount** instead of the gross deposit (`payment.amount`). Any subgraph/indexer that assumes `Refund.amount == original deposit` will need to update its queries — or read from `payment.amount` directly if the original deposit value is still needed.

## Impact

- **Correctness:** Recipient balance and arbiter debts now match the actual on-chain USDC movement
- **Risk:** Low — existing flows without prior `earlyWithdrawByArbiter` are unchanged (`withdrawnAmount` is 0, so `refundAmount == payment.amount`)
- **Test coverage:** No existing Solidity tests were found in the repo, so no tests were added in this PR. Recommended test case to add later:

deposit(100) → earlyWithdrawByArbiter(30) → refundByRecipient()
assert refundTo received 70 (not 100)
assert balances[recipient] decreased by 70