### PR TITLE
fix(docs): correct clone URL and directory name to circlefin/arc-escrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Automate escrow-backed freelance agreements with AI-powered work validation usin
 
    ```bash
    git clone git@github.com:circlefin/arc-escrow.git
-   cd workflow-escrow-refund-protocol
+   cd arc-escrow
    npm install
    ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Automate escrow-backed freelance agreements with AI-powered work validation usin
 1. Clone the repository and install dependencies:
 
    ```bash
-   git clone git@github.com:akelani-circle/workflow-escrow-refund-protocol.git
+   git clone git@github.com:circlefin/arc-escrow.git
    cd workflow-escrow-refund-protocol
    npm install
    ```


### PR DESCRIPTION
Fixes #16

The README clone URL and directory name still pointed to the original 
development fork (akelani-circle/workflow-escrow-refund-protocol). 
Updated both to the official repository (circlefin/arc-escrow).