### PR TITLE
fix: verify Circle webhook signature against raw request body

### DIFF
--- a/app/api/webhooks/circle/route.ts
+++ b/app/api/webhooks/circle/route.ts
@@ -154,16 +154,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const body = await req.json();
+    // Circle signs the RAW request bytes; verify against them, not a re-encode.
+    const rawBody = await req.text();
 
-    // Convert to a string for signature verification
-    const bodyString = JSON.stringify(body);
-
-    const isVerified = await verifyCircleSignature(bodyString, signature, keyId);
-
+    const isVerified = await verifyCircleSignature(rawBody, signature, keyId);
     if (!isVerified) {
       return NextResponse.json({ error: "Invalid signature" }, { status: 403 });
     }
+
+    // Parse only AFTER verification succeeds.
+    const body = JSON.parse(rawBody);
 
     console.log("Received notification:", body);
 


### PR DESCRIPTION
Similar to the recent fix in arc-p2p-payments, this prevents signature validation failures caused by re-serializing the JSON payload.

The webhook handler currently parses the request body and runs `JSON.stringify()` before verifying the signature. Since the re-serialized string is not guaranteed to be byte-for-byte identical to the original payload, valid webhooks can randomly get rejected.

This updates the handler to use `req.text()` for the cryptographic check and only parses the JSON after the signature is proven valid.