### PR TITLE
fix: validate full amount string before parsing

### DIFF
--- a/lib/utils/amount.ts
+++ b/lib/utils/amount.ts
@@ -22,10 +22,14 @@ export const parseAmount = (amountStr: string): number => {
     .replace(/[$€£,\s]/g, "")
     .replace(/−/g, "-");
 
-  // Parse the amount
-  const amount = parseFloat(cleanAmount);
+  // Validate the entire normalized string before parsing
+  if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/.test(cleanAmount)) {
+    throw new Error(`Invalid amount: ${amountStr}`);
+  }
 
-  if (Number.isNaN(amount) || amount <= 0) {
+  const amount = Number(cleanAmount);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
     throw new Error(`Invalid amount: ${amountStr}`);
   }
 


### PR DESCRIPTION
## Summary

Fixes #38 by validating the entire normalized amount string before converting it to a number.

`parseFloat()` accepts a valid numeric prefix and ignores trailing invalid characters, so inputs such as `10abc` or `1.25xyz` were previously accepted as `10` and `1.25`.

This change:

- validates the complete normalized string with a decimal-number pattern
- switches conversion from `parseFloat()` to `Number()` after validation
- keeps the existing positive/finite amount check
- preserves supported formatting normalization for currency symbols, commas, whitespace, parentheses, and Unicode minus

## Behavior

Valid examples continue to work:

- `$1,234.56` → `1234.56`
- `1,234.56` → `1234.56`
- `1.25` → `1.25`
- `.5` → `0.5`

Malformed values are now rejected:

- `10abc`
- `1.25xyz`
- `5USDCx`

## Testing

The repository does not currently include a test script/framework for this utility, so I verified the parsing behavior directly with Node and also ran `git diff --check` successfully.

Closes #38.