### PR TITLE
fix(amount): reject malformed numeric strings

### DIFF
--- a/lib/utils/amount.ts
+++ b/lib/utils/amount.ts
@@ -22,10 +22,16 @@ export const parseAmount = (amountStr: string): number => {
     .replace(/[$€£,\s]/g, "")
     .replace(/−/g, "-");
 
-  // Parse the amount
-  const amount = parseFloat(cleanAmount);
+  // Require the entire normalized value to be a decimal amount. parseFloat()
+  // alone accepts numeric prefixes such as "10abc" and silently ignores the
+  // malformed suffix.
+  if (!/^(?:\d+(?:\.\d*)?|\.\d+)$/.test(cleanAmount)) {
+    throw new Error(`Invalid amount: ${amountStr}`);
+  }
 
-  if (Number.isNaN(amount) || amount <= 0) {
+  const amount = Number(cleanAmount);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
     throw new Error(`Invalid amount: ${amountStr}`);
   }
 


### PR DESCRIPTION
Fixes #38
parseAmount previously relied on parseFloat, which accepts valid numeric prefixes and silently ignores malformed trailing characters such as 10abc or 1.25xyz.
This change validates the entire normalized amount string before conversion, while preserving the existing normalization for supported currency symbols, commas, whitespace, parentheses, and Unicode minus characters.
It also uses Number.isFinite to reject non-finite values.