### PR TITLE
Reject amount strings with trailing or invalid characters

### DIFF
--- a/lib/utils/amount.ts
+++ b/lib/utils/amount.ts
@@ -22,10 +22,16 @@ export const parseAmount = (amountStr: string): number => {
     .replace(/[$€£,\s]/g, "")
     .replace(/−/g, "-");
 
-  // Parse the amount
+  // The cleaned string must be a plain decimal in its entirety. parseFloat
+  // accepts a valid numeric prefix and ignores the rest, so "10abc" would parse
+  // as 10 and "1e5" as 100000 — both silently altering a monetary value.
+  if (!/^\d+(\.\d+)?$/.test(cleanAmount)) {
+    throw new Error(`Invalid amount: ${amountStr}`);
+  }
+
   const amount = parseFloat(cleanAmount);
 
-  if (Number.isNaN(amount) || amount <= 0) {
+  if (amount <= 0) {
     throw new Error(`Invalid amount: ${amountStr}`);
   }
 


### PR DESCRIPTION
`parseAmount` stripped formatting characters and then called `parseFloat`, which parses a leading numeric prefix and ignores the rest. So malformed strings were silently accepted as different values:

| input | before | after |
|---|---|---|
| `10abc` | `10` | rejected |
| `1.25xyz` | `1.25` | rejected |
| `1e5` | `100000` | rejected |
| `10` | `10` | `10` |
| `$1,000.50` | `1000.5` | `1000.5` |

Since `parseAmount` feeds deposit and refund flows, silently recording a different amount is the wrong failure mode for monetary values. The cleaned string is now required to be a plain decimal in its entirety before parsing.

Closes #38