### PR TITLE
fix(amount): round USDC to whole base units so the on-chain amount is an integer

### DIFF
--- a/lib/utils/amount.ts
+++ b/lib/utils/amount.ts
@@ -33,5 +33,9 @@ export const parseAmount = (amountStr: string): number => {
 };
 
 export function convertUSDCToContractAmount(amount: number): string {
-  return (amount * 1000000).toString();
+  // Round to whole base units: USDC has 6 decimals and the value is passed as a
+  // uint256, so the result has to be an integer. amount * 1000000 is float math,
+  // and ordinary amounts like 2.01 land just under (2009999.9999999998), which
+  // .toString() would carry through as a fractional, invalid on-chain amount.
+  return Math.round(amount * 1000000).toString();
 }


### PR DESCRIPTION
`convertUSDCToContractAmount` turns a USDC amount into 6-decimal base units for the `uint256` that `pay(address,uint256,address)` takes, but it scales in floating point: `(amount * 1000000).toString()`. Ordinary amounts land just under a whole unit — `2.01` becomes `"2009999.9999999998"`, `2.05` `"2049999.9999999998"`, `1.005` `"1004999.9999999999"` — and `.toString()` carries the fraction straight through. Around 3% of cent-precision amounts are affected.

Both deposit routes then do `Number(convertUSDCToContractAmount(...))` and pass the result as the `uint256` amount to the escrow `pay()` call (`app/api/contracts/escrow/deposit/route.ts`, `.../deposit/approve/route.ts`), so a plain $2.01 deposit goes on-chain as a non-integer amount — rejected by the encoder, or truncated a base unit short.

Rounding to the nearest base unit is the correct fixed-point conversion and restores the integer the function is meant to produce. Verified against the current values: `2.01`, `2.05`, `4.02`, `1.005` return fractional strings before the change and the exact base-unit integers after; `tsc --noEmit` and `prettier --check` stay clean.

Separate from #44, which fixes `parseAmount`.
